### PR TITLE
feat: Añadir sistema de votación y revisión comunitaria

### DIFF
--- a/src/main/java/com/jesusLuna/polyglotCloud/DTO/TranslationVersionDTO.java
+++ b/src/main/java/com/jesusLuna/polyglotCloud/DTO/TranslationVersionDTO.java
@@ -8,40 +8,48 @@ import jakarta.validation.constraints.Size;
 
 public class TranslationVersionDTO {
 
-    public record CreateVersionRequest(
-            @NotBlank(message = "Translated code is required")
-            String translatedCode,
-            
-            @Size(max = 1000, message = "Change notes cannot exceed 1000 characters")
-            String changeNotes
-    ) {}
+        public record CreateVersionRequest(
+                @NotBlank(message = "Translated code is required")
+                String translatedCode,
+                
+                @Size(max = 1000, message = "Change notes cannot exceed 1000 characters")
+                String changeNotes
+        ) {}
 
-    public record VersionResponse(
-            UUID id,
-            UUID translationId,
-            Integer versionNumber,
-            String translatedCode,
-            String authorName,
-            UUID authorId,
-            String changeNotes,
-            Boolean isCurrentVersion,
-            Instant createdAt
-    ) {}
+        public record VersionResponse(
+                UUID id,
+                UUID translationId,
+                Integer versionNumber,
+                String translatedCode,
+                String authorName,
+                UUID authorId,
+                String changeNotes,
+                Boolean isCurrentVersion,
+                Integer upvotesCount,
+                Integer downvotesCount,
+                Integer totalScore,
+                Double approvalRate,
+                Instant createdAt
+        ) {}
 
-    public record VersionSummary(
-            UUID id,
-            Integer versionNumber,
-            String authorName,
-            UUID authorId,
-            String changeNotes,
-            Boolean isCurrentVersion,
-            Instant createdAt
-    ) {}
+        public record VersionSummary(
+                UUID id,
+                Integer versionNumber,
+                String authorName,
+                UUID authorId,
+                String changeNotes,
+                Boolean isCurrentVersion,
+                Integer upvotesCount,
+                Integer downvotesCount,
+                Integer totalScore,
+                Double approvalRate,
+                Instant createdAt
+        ) {}
 
-    public record VersionHistory(
-            UUID translationId,
-            Integer totalVersions,
-            Integer currentVersionNumber,
-            java.util.List<VersionSummary> versions
-    ) {}
+        public record VersionHistory(
+                UUID translationId,
+                Integer totalVersions,
+                Integer currentVersionNumber,
+                java.util.List<VersionSummary> versions
+        ) {}
 }

--- a/src/main/java/com/jesusLuna/polyglotCloud/DTO/TranslationVoteDTO.java
+++ b/src/main/java/com/jesusLuna/polyglotCloud/DTO/TranslationVoteDTO.java
@@ -1,0 +1,55 @@
+package com.jesusLuna.polyglotCloud.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.jesusLuna.polyglotCloud.models.enums.VoteType;
+
+import jakarta.validation.constraints.NotNull;
+
+public class TranslationVoteDTO {
+
+    public record VoteRequest(
+            @NotNull(message = "Vote type is required")
+            VoteType voteType
+    ) {}
+
+    public record VoteResponse(
+            UUID id,
+            UUID versionId,
+            UUID userId,
+            String username,
+            VoteType voteType,
+            Instant createdAt,
+            Instant updatedAt
+    ) {}
+
+    public record VoteStats(
+            UUID versionId,
+            Integer upvotesCount,
+            Integer downvotesCount,
+            Integer totalScore,
+            Integer totalVotes,
+            Double approvalRate,
+            Boolean userHasVoted,
+            VoteType userVoteType
+    ) {}
+
+    public record VersionWithVotes(
+            UUID id,
+            Integer versionNumber,
+            String translatedCode,
+            String authorName,
+            UUID authorId,
+            String changeNotes,
+            Boolean isCurrentVersion,
+            VoteStats voteStats,
+            Instant createdAt
+    ) {}
+
+    public record TopVersions(
+            UUID translationId,
+            java.util.List<VersionWithVotes> topVersionsByScore,
+            java.util.List<VersionWithVotes> recentVersions
+    ) {}
+}

--- a/src/main/java/com/jesusLuna/polyglotCloud/controller/TranslationRankingController.java
+++ b/src/main/java/com/jesusLuna/polyglotCloud/controller/TranslationRankingController.java
@@ -1,0 +1,68 @@
+package com.jesusLuna.polyglotCloud.controller;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.jesusLuna.polyglotCloud.dto.TranslationVoteDTO;
+import com.jesusLuna.polyglotCloud.service.TranslationVoteService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/translations")
+@Tag(name = "Translation Rankings", description = "Community rankings and top translations")
+@SecurityRequirement(name = "Bearer Authentication")
+public class TranslationRankingController {
+
+    private final TranslationVoteService voteService;
+
+    @GetMapping("/{translationId}/top-versions")
+    @Operation(
+        summary = "Get top translation versions",
+        description = "Retrieves the best-rated and most recent versions of a translation"
+    )
+    @ApiResponse(responseCode = "200", description = "Top versions retrieved successfully")
+    public ResponseEntity<TranslationVoteDTO.TopVersions> getTopVersions(
+            @PathVariable UUID translationId,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails) {
+
+        UUID currentUserId = userDetails != null ? UUID.fromString(userDetails.getUsername()) : null;
+        
+        TranslationVoteDTO.TopVersions topVersions = voteService.getTopVersions(translationId, currentUserId);
+        
+        return ResponseEntity.ok(topVersions);
+    }
+
+    @GetMapping("/users/{userId}/votes")
+    @Operation(
+        summary = "Get user votes",
+        description = "Retrieves voting history for a specific user"
+    )
+    @ApiResponse(responseCode = "200", description = "User votes retrieved successfully")
+    public ResponseEntity<Page<TranslationVoteDTO.VoteResponse>> getUserVotes(
+            @PathVariable UUID userId,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) 
+            Pageable pageable) {
+
+        Page<TranslationVoteDTO.VoteResponse> votes = voteService.getUserVotes(userId, pageable);
+        
+        return ResponseEntity.ok(votes);
+    }
+}

--- a/src/main/java/com/jesusLuna/polyglotCloud/mapper/TranslationVoteMapper.java
+++ b/src/main/java/com/jesusLuna/polyglotCloud/mapper/TranslationVoteMapper.java
@@ -1,0 +1,16 @@
+package com.jesusLuna.polyglotCloud.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import com.jesusLuna.polyglotCloud.dto.TranslationVoteDTO;
+import com.jesusLuna.polyglotCloud.models.Translations.TranslationVote;
+
+@Mapper(componentModel = "spring")
+public interface TranslationVoteMapper {
+
+    @Mapping(source = "translationVersion.id", target = "versionId")
+    @Mapping(source = "user.id", target = "userId")
+    @Mapping(source = "user.username", target = "username")
+    TranslationVoteDTO.VoteResponse toResponse(TranslationVote vote);
+}

--- a/src/main/java/com/jesusLuna/polyglotCloud/models/Translations/TranslationVersion.java
+++ b/src/main/java/com/jesusLuna/polyglotCloud/models/Translations/TranslationVersion.java
@@ -1,5 +1,7 @@
 package com.jesusLuna.polyglotCloud.models.Translations;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.annotation.CreatedDate;
@@ -7,6 +9,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.jesusLuna.polyglotCloud.models.User;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -16,6 +19,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -64,6 +68,22 @@ public class TranslationVersion {
     @Builder.Default
     private Boolean isCurrentVersion = false;
 
+    @Column(name = "upvotes_count", nullable = false)
+    @Builder.Default
+    private Integer upvotesCount = 0;
+
+    @Column(name = "downvotes_count", nullable = false)
+    @Builder.Default
+    private Integer downvotesCount = 0;
+
+    @Column(name = "total_score", nullable = false)
+    @Builder.Default
+    private Integer totalScore = 0;
+
+    @OneToMany(mappedBy = "translationVersion", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<TranslationVote> votes = new ArrayList<>();
+
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
@@ -80,5 +100,52 @@ public class TranslationVersion {
      */
     public void unmarkAsCurrent() {
         this.isCurrentVersion = false;
+    }
+
+    /**
+     * Recalcula las puntuaciones basándose en los votos
+     */
+    public void recalculateScores() {
+        this.upvotesCount = (int) votes.stream()
+                .filter(vote -> vote.getVoteType().isUpvote())
+                .count();
+        
+        this.downvotesCount = (int) votes.stream()
+                .filter(vote -> vote.getVoteType().isDownvote())
+                .count();
+        
+        this.totalScore = upvotesCount - downvotesCount;
+    }
+
+    /**
+     * Obtiene la puntuación neta (upvotes - downvotes)
+     */
+    public Integer getNetScore() {
+        return totalScore;
+    }
+
+    /**
+     * Obtiene el total de votos (upvotes + downvotes)
+     */
+    public Integer getTotalVotes() {
+        return upvotesCount + downvotesCount;
+    }
+
+    /**
+     * Calcula el porcentaje de aprobación
+     */
+    public Double getApprovalRate() {
+        int totalVotes = getTotalVotes();
+        if (totalVotes == 0) {
+            return 0.0;
+        }
+        return (double) upvotesCount / totalVotes * 100;
+    }
+
+    /**
+     * Verifica si esta versión tiene suficiente puntuación para auto-aprobación
+     */
+    public boolean hasHighEnoughScoreForAutoApproval(int threshold) {
+        return totalScore >= threshold && upvotesCount >= 3; // Mínimo 3 votos positivos
     }
 }

--- a/src/main/java/com/jesusLuna/polyglotCloud/models/Translations/TranslationVote.java
+++ b/src/main/java/com/jesusLuna/polyglotCloud/models/Translations/TranslationVote.java
@@ -1,0 +1,81 @@
+package com.jesusLuna.polyglotCloud.models.Translations;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.jesusLuna.polyglotCloud.models.User;
+import com.jesusLuna.polyglotCloud.models.enums.VoteType;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "translation_votes",
+    uniqueConstraints = @UniqueConstraint(
+        columnNames = {"translation_version_id", "user_id"},
+        name = "uk_translation_vote_user_version"
+    )
+)
+@EntityListeners(AuditingEntityListener.class)
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TranslationVote {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "translation_version_id", nullable = false)
+    private TranslationVersion translationVersion;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private VoteType voteType;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    /**
+     * Cambia el tipo de voto (facilita cambiar de upvote a downvote y viceversa)
+     */
+    public void changeVoteType(VoteType newVoteType) {
+        this.voteType = newVoteType;
+    }
+}

--- a/src/main/java/com/jesusLuna/polyglotCloud/models/enums/VoteType.java
+++ b/src/main/java/com/jesusLuna/polyglotCloud/models/enums/VoteType.java
@@ -1,0 +1,48 @@
+package com.jesusLuna.polyglotCloud.models.enums;
+
+public enum VoteType {
+    /**
+     * Voto positivo (+1)
+     */
+    UPVOTE(1),
+    
+    /**
+     * Voto negativo (-1)
+     */
+    DOWNVOTE(-1);
+
+    private final int value;
+
+    VoteType(int value) {
+        this.value = value;
+    }
+
+    /**
+     * Obtiene el valor numérico del voto para cálculos
+     * @return +1 para UPVOTE, -1 para DOWNVOTE
+     */
+    public int getValue() {
+        return value;
+    }
+
+    /**
+     * Verifica si es un voto positivo
+     */
+    public boolean isUpvote() {
+        return this == UPVOTE;
+    }
+
+    /**
+     * Verifica si es un voto negativo
+     */
+    public boolean isDownvote() {
+        return this == DOWNVOTE;
+    }
+
+    /**
+     * Obtiene el tipo de voto opuesto
+     */
+    public VoteType opposite() {
+        return this == UPVOTE ? DOWNVOTE : UPVOTE;
+    }
+}

--- a/src/main/java/com/jesusLuna/polyglotCloud/repository/TranslationVoteRepository.java
+++ b/src/main/java/com/jesusLuna/polyglotCloud/repository/TranslationVoteRepository.java
@@ -1,0 +1,67 @@
+package com.jesusLuna.polyglotCloud.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.jesusLuna.polyglotCloud.models.Translations.TranslationVote;
+import com.jesusLuna.polyglotCloud.models.enums.VoteType;
+
+@Repository
+public interface TranslationVoteRepository extends JpaRepository<TranslationVote, UUID> {
+
+    @EntityGraph(attributePaths = {"translationVersion", "user"})
+    Optional<TranslationVote> findById(UUID id);
+
+    @EntityGraph(attributePaths = {"user"})
+    Optional<TranslationVote> findByTranslationVersionIdAndUserId(
+            @Param("versionId") UUID versionId, 
+            @Param("userId") UUID userId
+    );
+
+    @EntityGraph(attributePaths = {"user"})
+    List<TranslationVote> findByTranslationVersionIdOrderByCreatedAtDesc(
+            @Param("versionId") UUID versionId
+    );
+
+    @EntityGraph(attributePaths = {"user"})
+    Page<TranslationVote> findByTranslationVersionIdOrderByCreatedAtDesc(
+            @Param("versionId") UUID versionId, 
+            Pageable pageable
+    );
+
+    @Query("SELECT COUNT(tv) FROM TranslationVote tv WHERE tv.translationVersion.id = :versionId AND tv.voteType = :voteType")
+    long countByTranslationVersionIdAndVoteType(
+            @Param("versionId") UUID versionId, 
+            @Param("voteType") VoteType voteType
+    );
+
+    @Query("SELECT COUNT(tv) FROM TranslationVote tv WHERE tv.translationVersion.id = :versionId")
+    long countByTranslationVersionId(@Param("versionId") UUID versionId);
+
+    @Query("SELECT COALESCE(SUM(CASE WHEN tv.voteType = 'UPVOTE' THEN 1 WHEN tv.voteType = 'DOWNVOTE' THEN -1 ELSE 0 END), 0) " +
+        "FROM TranslationVote tv WHERE tv.translationVersion.id = :versionId")
+    int calculateNetScore(@Param("versionId") UUID versionId);
+
+    @Query("SELECT tv FROM TranslationVote tv WHERE tv.user.id = :userId ORDER BY tv.createdAt DESC")
+    Page<TranslationVote> findByUserIdOrderByCreatedAtDesc(@Param("userId") UUID userId, Pageable pageable);
+
+    @Query("SELECT tv FROM TranslationVote tv WHERE tv.translationVersion.id IN :versionIds AND tv.user.id = :userId")
+    List<TranslationVote> findByVersionIdsAndUserId(
+            @Param("versionIds") List<UUID> versionIds,
+            @Param("userId") UUID userId
+    );
+
+    boolean existsByTranslationVersionIdAndUserId(
+            @Param("versionId") UUID versionId,
+            @Param("userId") UUID userId
+    );
+}

--- a/src/main/java/com/jesusLuna/polyglotCloud/service/TranslationVoteService.java
+++ b/src/main/java/com/jesusLuna/polyglotCloud/service/TranslationVoteService.java
@@ -1,0 +1,277 @@
+package com.jesusLuna.polyglotCloud.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.jesusLuna.polyglotCloud.dto.TranslationVoteDTO;
+import com.jesusLuna.polyglotCloud.exception.BusinessRuleException;
+import com.jesusLuna.polyglotCloud.exception.ResourceNotFoundException;
+import com.jesusLuna.polyglotCloud.mapper.TranslationVoteMapper;
+import com.jesusLuna.polyglotCloud.models.Translations.TranslationVersion;
+import com.jesusLuna.polyglotCloud.models.Translations.TranslationVote;
+import com.jesusLuna.polyglotCloud.models.User;
+import com.jesusLuna.polyglotCloud.models.enums.VoteType;
+import com.jesusLuna.polyglotCloud.repository.TranslationVersionRepository;
+import com.jesusLuna.polyglotCloud.repository.TranslationVoteRepository;
+import com.jesusLuna.polyglotCloud.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class TranslationVoteService {
+
+    private final TranslationVoteRepository voteRepository;
+    private final TranslationVersionRepository versionRepository;
+    private final UserRepository userRepository;
+    private final TranslationVoteMapper voteMapper;
+    private final CacheService cacheService;
+
+    @Transactional
+    public TranslationVoteDTO.VoteResponse vote(
+            UUID versionId, 
+            TranslationVoteDTO.VoteRequest request, 
+            UUID userId) {
+        
+        log.info("User {} voting {} on version {}", userId, request.voteType(), versionId);
+
+        // Validar versión
+        TranslationVersion version = versionRepository.findById(versionId)
+                .orElseThrow(() -> new ResourceNotFoundException("Translation version", "id", versionId));
+
+        // Validar usuario
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", "id", userId));
+
+        // Validar que no vote su propia versión
+        if (version.getAuthor().getId().equals(userId)) {
+            throw new BusinessRuleException("Cannot vote on your own translation version");
+        }
+
+        // Buscar voto existente
+        var existingVote = voteRepository.findByTranslationVersionIdAndUserId(versionId, userId);
+        TranslationVote vote;
+
+        if (existingVote.isPresent()) {
+            // Cambiar voto existente
+            vote = existingVote.get();
+            
+            if (vote.getVoteType() == request.voteType()) {
+                throw new BusinessRuleException("You have already cast this type of vote on this version");
+            }
+            
+            log.info("Changing vote from {} to {} for version {}", 
+                    vote.getVoteType(), request.voteType(), versionId);
+            vote.changeVoteType(request.voteType());
+        } else {
+            // Crear nuevo voto
+            vote = TranslationVote.builder()
+                    .translationVersion(version)
+                    .user(user)
+                    .voteType(request.voteType())
+                    .build();
+        }
+
+        TranslationVote savedVote = voteRepository.save(vote);
+
+        // Recalcular puntuaciones de la versión
+        updateVersionScores(version);
+
+        // Limpiar cache relacionado
+        clearVersionCaches(version);
+
+        // Verificar si esta versión debería ser auto-aprobada
+        checkForAutoApproval(version);
+
+        return voteMapper.toResponse(savedVote);
+    }
+
+    @Transactional
+    public void removeVote(UUID versionId, UUID userId) {
+        log.info("User {} removing vote from version {}", userId, versionId);
+
+        TranslationVote vote = voteRepository.findByTranslationVersionIdAndUserId(versionId, userId)
+                .orElseThrow(() -> new ResourceNotFoundException("Vote not found for this user and version"));
+
+        TranslationVersion version = vote.getTranslationVersion();
+        
+        voteRepository.delete(vote);
+
+        // Recalcular puntuaciones
+        updateVersionScores(version);
+        clearVersionCaches(version);
+    }
+
+    public TranslationVoteDTO.VoteStats getVoteStats(UUID versionId, UUID currentUserId) {
+        TranslationVersion version = versionRepository.findById(versionId)
+                .orElseThrow(() -> new ResourceNotFoundException("Translation version", "id", versionId));
+
+        // Obtener voto del usuario actual si existe
+        var userVote = currentUserId != null ? 
+                voteRepository.findByTranslationVersionIdAndUserId(versionId, currentUserId) : 
+                null;
+
+        // Usar constructor del record
+        return new TranslationVoteDTO.VoteStats(
+            versionId,
+            version.getUpvotesCount(),
+            version.getDownvotesCount(),
+            version.getTotalScore(),
+            version.getTotalVotes(),
+            version.getApprovalRate(),
+            userVote.isPresent(),
+            userVote.map(TranslationVote::getVoteType).orElse(null)
+        );
+    }
+
+    public Page<TranslationVoteDTO.VoteResponse> getVersionVotes(UUID versionId, Pageable pageable) {
+        // Verificar que la versión existe
+        if (!versionRepository.existsById(versionId)) {
+            throw new ResourceNotFoundException("Translation version", "id", versionId);
+        }
+
+        Page<TranslationVote> votes = voteRepository
+                .findByTranslationVersionIdOrderByCreatedAtDesc(versionId, pageable);
+
+        return votes.map(voteMapper::toResponse);
+    }
+
+    public Page<TranslationVoteDTO.VoteResponse> getUserVotes(UUID userId, Pageable pageable) {
+        // Verificar que el usuario existe
+        if (!userRepository.existsById(userId)) {
+            throw new ResourceNotFoundException("User", "id", userId);
+        }
+
+        Page<TranslationVote> votes = voteRepository
+                .findByUserIdOrderByCreatedAtDesc(userId, pageable);
+
+        return votes.map(voteMapper::toResponse);
+    }
+
+    /**
+     * Obtiene versiones ordenadas por puntuación para una traducción
+     */
+    public TranslationVoteDTO.TopVersions getTopVersions(UUID translationId, UUID currentUserId) {
+        List<TranslationVersion> allVersions = versionRepository
+                .findByTranslationIdOrderByVersionNumberAsc(translationId);
+
+        if (allVersions.isEmpty()) {
+            return new TranslationVoteDTO.TopVersions(translationId, List.of(), List.of());
+        }
+
+        // Obtener votos del usuario actual para estas versiones si está logueado
+        Map<UUID, VoteType> userVotes = Map.of();
+        if (currentUserId != null) {
+            List<UUID> versionIds = allVersions.stream()
+                    .map(TranslationVersion::getId)
+                    .collect(Collectors.toList());
+            
+            userVotes = voteRepository.findByVersionIdsAndUserId(versionIds, currentUserId)
+                    .stream()
+                    .collect(Collectors.toMap(
+                        vote -> vote.getTranslationVersion().getId(),
+                        TranslationVote::getVoteType
+                    ));
+        }
+
+        final Map<UUID, VoteType> finalUserVotes = userVotes;
+
+        // Convertir a DTO con estadísticas de votación
+        List<TranslationVoteDTO.VersionWithVotes> versionsWithVotes = allVersions.stream()
+                .map(version -> mapVersionWithVotes(version, finalUserVotes))
+                .collect(Collectors.toList());
+
+        // Top por puntuación (mejores primero)
+        List<TranslationVoteDTO.VersionWithVotes> topByScore = versionsWithVotes.stream()
+                .sorted((v1, v2) -> Integer.compare(
+                    v2.voteStats().totalScore(), 
+                    v1.voteStats().totalScore()
+                ))
+                .limit(5)
+                .collect(Collectors.toList());
+
+        // Recientes (últimas primero)
+        List<TranslationVoteDTO.VersionWithVotes> recent = versionsWithVotes.stream()
+                .sorted((v1, v2) -> v2.createdAt().compareTo(v1.createdAt()))
+                .limit(5)
+                .collect(Collectors.toList());
+
+        return new TranslationVoteDTO.TopVersions(translationId, topByScore, recent);
+    }
+
+    @Transactional
+    protected void updateVersionScores(TranslationVersion version) {
+        // Refrescar la versión con sus votos
+        version = versionRepository.findById(version.getId()).orElseThrow();
+        
+        // Recalcular puntuaciones
+        version.recalculateScores();
+        
+        versionRepository.save(version);
+        
+        log.debug("Updated scores for version {}: {} upvotes, {} downvotes, {} total score",
+                version.getId(), version.getUpvotesCount(), version.getDownvotesCount(), version.getTotalScore());
+    }
+
+    private void clearVersionCaches(TranslationVersion version) {
+        // Limpiar caches relacionados
+        cacheService.delete("translation::" + version.getTranslation().getId());
+        cacheService.deletePattern("version::*");
+        cacheService.deletePattern("vote::*");
+    }
+
+    private void checkForAutoApproval(TranslationVersion version) {
+        // Configuración de auto-aprobación
+        final int AUTO_APPROVAL_THRESHOLD = 5; // Puntuación mínima para auto-aprobación
+        
+        if (version.hasHighEnoughScoreForAutoApproval(AUTO_APPROVAL_THRESHOLD)) {
+            log.info("Version {} has reached auto-approval threshold with score {}", 
+                    version.getId(), version.getTotalScore());
+            
+            // Aquí puedes disparar eventos o notificaciones para moderadores
+            // O directamente auto-aprobar si es la política de tu aplicación
+        }
+    }
+
+    private TranslationVoteDTO.VersionWithVotes mapVersionWithVotes(
+            TranslationVersion version, 
+            Map<UUID, VoteType> userVotes) {
+        
+        VoteType userVoteType = userVotes.get(version.getId());
+        
+        // Usa el constructor del record directamente
+        TranslationVoteDTO.VoteStats voteStats = new TranslationVoteDTO.VoteStats(
+            version.getId(),           // versionId
+            version.getUpvotesCount(), // upvotesCount
+            version.getDownvotesCount(), // downvotesCount
+            version.getTotalScore(),   // totalScore
+            version.getTotalVotes(),   // totalVotes
+            version.getApprovalRate(), // approvalRate
+            userVoteType != null,      // userHasVoted
+            userVoteType               // userVoteType
+        );
+
+        // Usar constructor del record
+        return new TranslationVoteDTO.VersionWithVotes(
+            version.getId(),
+            version.getVersionNumber(),
+            version.getTranslatedCode(),
+            version.getAuthor().getUsername(),
+            version.getAuthor().getId(),
+            version.getChangeNotes(),
+            version.getIsCurrentVersion(),
+            voteStats,
+            version.getCreatedAt()
+        );
+    }
+}

--- a/src/main/resources/db/migration/V0011__create_translation_votes_table.sql
+++ b/src/main/resources/db/migration/V0011__create_translation_votes_table.sql
@@ -1,0 +1,74 @@
+-- Add vote counting columns to translation_versions table
+ALTER TABLE translation_versions 
+ADD COLUMN upvotes_count INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN downvotes_count INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN total_score INTEGER NOT NULL DEFAULT 0;
+
+-- Create translation_votes table
+CREATE TABLE translation_votes (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    translation_version_id UUID NOT NULL REFERENCES translation_versions(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    vote_type VARCHAR(20) NOT NULL CHECK (vote_type IN ('UPVOTE', 'DOWNVOTE')),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_translation_vote_user_version UNIQUE (translation_version_id, user_id)
+);
+
+-- Indices for performance
+CREATE INDEX idx_translation_votes_version_id ON translation_votes(translation_version_id);
+CREATE INDEX idx_translation_votes_user_id ON translation_votes(user_id);
+CREATE INDEX idx_translation_votes_vote_type ON translation_votes(vote_type);
+CREATE INDEX idx_translation_votes_created_at ON translation_votes(created_at);
+
+-- Index on translation_versions for voting queries
+CREATE INDEX idx_translation_versions_score ON translation_versions(total_score DESC);
+CREATE INDEX idx_translation_versions_upvotes ON translation_versions(upvotes_count DESC);
+
+-- Function to update vote counts when votes are added/updated/deleted
+CREATE OR REPLACE FUNCTION update_version_vote_counts()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Update the translation_version vote counts
+    UPDATE translation_versions 
+    SET 
+        upvotes_count = (
+            SELECT COUNT(*) 
+            FROM translation_votes 
+            WHERE translation_version_id = COALESCE(NEW.translation_version_id, OLD.translation_version_id) 
+            AND vote_type = 'UPVOTE'
+        ),
+        downvotes_count = (
+            SELECT COUNT(*) 
+            FROM translation_votes 
+            WHERE translation_version_id = COALESCE(NEW.translation_version_id, OLD.translation_version_id) 
+            AND vote_type = 'DOWNVOTE'
+        ),
+        total_score = (
+            SELECT COALESCE(SUM(
+                CASE 
+                    WHEN vote_type = 'UPVOTE' THEN 1 
+                    WHEN vote_type = 'DOWNVOTE' THEN -1 
+                    ELSE 0 
+                END
+            ), 0)
+            FROM translation_votes 
+            WHERE translation_version_id = COALESCE(NEW.translation_version_id, OLD.translation_version_id)
+        )
+    WHERE id = COALESCE(NEW.translation_version_id, OLD.translation_version_id);
+    
+    RETURN COALESCE(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger to automatically update vote counts
+CREATE TRIGGER trigger_update_version_vote_counts
+    AFTER INSERT OR UPDATE OR DELETE ON translation_votes
+    FOR EACH ROW
+    EXECUTE FUNCTION update_version_vote_counts();
+
+-- Trigger para actualizar updated_at en votes
+CREATE TRIGGER update_translation_votes_updated_at 
+    BEFORE UPDATE ON translation_votes 
+    FOR EACH ROW 
+    EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
This pull request introduces a comprehensive voting system for translation versions, enabling users to upvote or downvote translations, view voting statistics, and retrieve top-rated versions. The changes span model updates, new DTOs, repository logic, controller endpoints, and mapping utilities to support community-driven translation rankings.

**Voting System Core Functionality**

* Added the `TranslationVote` entity to represent user votes on translation versions, including vote type (upvote/downvote), user, and timestamps.
* Introduced the `VoteType` enum to distinguish between upvotes and downvotes, along with utility methods for vote calculations.
* Updated the `TranslationVersion` model to include vote statistics fields (`upvotesCount`, `downvotesCount`, `totalScore`) and methods for recalculating and retrieving voting statistics. [[1]](diffhunk://#diff-afb752fe870aa43182655dbd69d4c4672cf5b1c9492fb0dcd49a238c00872282R71-R86) [[2]](diffhunk://#diff-afb752fe870aa43182655dbd69d4c4672cf5b1c9492fb0dcd49a238c00872282R104-R150)

**DTOs and Data Transfer Enhancements**

* Created `TranslationVoteDTO` with request/response records, vote statistics, and structures for returning top and recent versions with voting data.
* Extended `VersionResponse` and `VersionSummary` records to include voting statistics, such as upvotes, downvotes, total score, and approval rate. [[1]](diffhunk://#diff-1e502628338e2310bd84b4c03a41203866f01e1ccc9a08c6f3dd027c8e3120c9R28-R31) [[2]](diffhunk://#diff-1e502628338e2310bd84b4c03a41203866f01e1ccc9a08c6f3dd027c8e3120c9R42-R45)

**Persistence and Querying**

* Added `TranslationVoteRepository` with methods for querying votes by version/user, counting votes, calculating net score, and checking vote existence, including custom JPQL queries for efficiency.

**API Endpoints and Controller Logic**

* Introduced `TranslationRankingController` to provide endpoints for fetching top-rated/recent translation versions and user voting history, utilizing the new voting system.

**Mapping and Conversion**

* Implemented `TranslationVoteMapper` using MapStruct to convert between `TranslationVote` entities and their DTO representations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added voting system: users can upvote or downvote translation versions
  * Translation versions now display vote counts, approval ratings, and total scores
  * Browse top-ranked and recently updated translation versions
  * View your personal voting history for all translations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->